### PR TITLE
tracking subqueries (which will be needed for join promotion/hoisting)

### DIFF
--- a/src/main/antlr/org/hibernate/sqm/parser/hql/internal/antlr/HqlParser.g4
+++ b/src/main/antlr/org/hibernate/sqm/parser/hql/internal/antlr/HqlParser.g4
@@ -118,6 +118,7 @@ resultIdentifier
 	;
 
 selectExpression
+	// todo : limit the viability of dynamicInstantiation and jpaSelectObjectSyntax to only the root query for select-statements
 	:	dynamicInstantiation
 	|	jpaSelectObjectSyntax
 	|	expression

--- a/src/main/java/org/hibernate/sqm/BaseSemanticQueryWalker.java
+++ b/src/main/java/org/hibernate/sqm/BaseSemanticQueryWalker.java
@@ -134,7 +134,7 @@ public class BaseSemanticQueryWalker<T> implements SemanticQueryWalker<T> {
 
 	@Override
 	public T visitInsertSelectStatement(SqmInsertSelectStatement statement) {
-		visitRootEntityFromElement( statement.getInsertTarget() );
+		visitRootEntityFromElement( statement.getEntityFromElement() );
 		for ( SingularAttributeBinding stateField : statement.getStateFields() ) {
 			stateField.accept( this );
 		}

--- a/src/main/java/org/hibernate/sqm/parser/common/QuerySpecProcessingState.java
+++ b/src/main/java/org/hibernate/sqm/parser/common/QuerySpecProcessingState.java
@@ -7,11 +7,17 @@
 package org.hibernate.sqm.parser.common;
 
 import org.hibernate.sqm.query.from.SqmFromClause;
+import org.hibernate.sqm.query.from.SqmFromClauseContainer;
+import org.hibernate.sqm.query.internal.InFlightSqmSubQueryContainer;
 
 /**
  * @author Steve Ebersole
  */
 public interface QuerySpecProcessingState extends FromElementLocator, ResolutionContext {
 	QuerySpecProcessingState getParent();
-	SqmFromClause getFromClause();
+	SqmFromClauseContainer getFromClauseContainer();
+	InFlightSqmSubQueryContainer getSubQueryContainer();
+	default SqmFromClause getFromClause() {
+		return getFromClauseContainer().getFromClause();
+	}
 }

--- a/src/main/java/org/hibernate/sqm/parser/common/Stack.java
+++ b/src/main/java/org/hibernate/sqm/parser/common/Stack.java
@@ -11,7 +11,7 @@ import java.util.LinkedList;
 /**
  * A general-purpose stack impl for use in parsing.
  *
- * @param <T> The type of things stired in the stack
+ * @param <T> The type of things stored in the stack
  *
  * @author Steve Ebersole
  */
@@ -27,6 +27,6 @@ public class Stack<T> {
 	}
 
 	public T getCurrent() {
-		return stack.getFirst();
+		return stack.peek();
 	}
 }

--- a/src/main/java/org/hibernate/sqm/query/SqmDeleteStatement.java
+++ b/src/main/java/org/hibernate/sqm/query/SqmDeleteStatement.java
@@ -6,12 +6,10 @@
  */
 package org.hibernate.sqm.query;
 
-import org.hibernate.sqm.query.from.SqmRoot;
 import org.hibernate.sqm.query.predicate.SqmWhereClauseContainer;
 
 /**
  * @author Steve Ebersole
  */
 public interface SqmDeleteStatement extends SqmStatementNonSelect, SqmWhereClauseContainer {
-	SqmRoot getEntityFromElement();
 }

--- a/src/main/java/org/hibernate/sqm/query/SqmInsertStatement.java
+++ b/src/main/java/org/hibernate/sqm/query/SqmInsertStatement.java
@@ -9,7 +9,6 @@ package org.hibernate.sqm.query;
 import java.util.List;
 
 import org.hibernate.sqm.query.expression.domain.SingularAttributeBinding;
-import org.hibernate.sqm.query.from.SqmRoot;
 
 /**
  * The general contract for INSERT statements.  At the moment only the INSERT-SELECT
@@ -17,7 +16,6 @@ import org.hibernate.sqm.query.from.SqmRoot;
  *
  * @author Steve Ebersole
  */
-public interface SqmInsertStatement extends SqmStatement {
-	SqmRoot getInsertTarget();
+public interface SqmInsertStatement extends SqmStatementNonSelect {
 	List<SingularAttributeBinding> getStateFields();
 }

--- a/src/main/java/org/hibernate/sqm/query/SqmQuerySpec.java
+++ b/src/main/java/org/hibernate/sqm/query/SqmQuerySpec.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.sqm.query;
 
+import java.util.List;
+
 import org.hibernate.sqm.query.from.SqmFromClause;
 import org.hibernate.sqm.query.from.SqmFromClauseContainer;
 import org.hibernate.sqm.query.predicate.SqmWhereClause;
@@ -17,33 +19,6 @@ import org.hibernate.sqm.query.select.SqmSelectClause;
  *
  * @author Steve Ebersole
  */
-public class SqmQuerySpec implements SqmFromClauseContainer, SqmWhereClauseContainer {
-	private final SqmFromClause fromClause;
-	private final SqmSelectClause selectClause;
-	private final SqmWhereClause whereClause;
-
-	// todo : group-by + having
-
-	public SqmQuerySpec(
-			SqmFromClause fromClause,
-			SqmSelectClause selectClause,
-			SqmWhereClause whereClause) {
-		this.fromClause = fromClause;
-		this.selectClause = selectClause;
-		this.whereClause = whereClause;
-	}
-
-	public SqmSelectClause getSelectClause() {
-		return selectClause;
-	}
-
-	@Override
-	public SqmFromClause getFromClause() {
-		return fromClause;
-	}
-
-	@Override
-	public SqmWhereClause getWhereClause() {
-		return whereClause;
-	}
+public interface SqmQuerySpec extends SqmFromClauseContainer, SqmWhereClauseContainer {
+	SqmSelectClause getSelectClause();
 }

--- a/src/main/java/org/hibernate/sqm/query/SqmStatementNonSelect.java
+++ b/src/main/java/org/hibernate/sqm/query/SqmStatementNonSelect.java
@@ -6,10 +6,13 @@
  */
 package org.hibernate.sqm.query;
 
+import org.hibernate.sqm.query.from.SqmRoot;
+
 /**
  * Used to more easily identifier non-SELECT (DML) statements by gross type.
  *
  * @author Steve Ebersole
  */
 public interface SqmStatementNonSelect extends SqmStatement {
+	SqmRoot getEntityFromElement();
 }

--- a/src/main/java/org/hibernate/sqm/query/SqmSubQueryContainer.java
+++ b/src/main/java/org/hibernate/sqm/query/SqmSubQueryContainer.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sqm.query;
+
+import java.util.List;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface SqmSubQueryContainer {
+	List<SqmQuerySpec> getSubQuerySpecs();
+}

--- a/src/main/java/org/hibernate/sqm/query/SqmUpdateStatement.java
+++ b/src/main/java/org/hibernate/sqm/query/SqmUpdateStatement.java
@@ -15,7 +15,6 @@ import org.hibernate.sqm.query.set.SqmSetClause;
  * @author Steve Ebersole
  */
 public interface SqmUpdateStatement extends SqmStatementNonSelect, SqmWhereClauseContainer {
-	SqmRoot getEntityFromElement();
 	SqmSetClause getSetClause();
 	SqmWhereClause getWhereClause();
 }

--- a/src/main/java/org/hibernate/sqm/query/from/SqmFromClause.java
+++ b/src/main/java/org/hibernate/sqm/query/from/SqmFromClause.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.sqm.query.from;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -17,19 +16,12 @@ import java.util.List;
  *
  * @author Steve Ebersole
  */
-public class SqmFromClause {
-	private List<FromElementSpace> fromElementSpaces = new ArrayList<FromElementSpace>();
+public interface SqmFromClause {
+	SqmFromClauseContainer getContainer();
 
-	public List<FromElementSpace> getFromElementSpaces() {
-		return fromElementSpaces;
-	}
+	List<FromElementSpace> getFromElementSpaces();
 
-	public void addFromElementSpace(FromElementSpace space) {
+	void addFromElementSpace(FromElementSpace space);
 
-	}
-	public FromElementSpace makeFromElementSpace() {
-		final FromElementSpace space = new FromElementSpace( this );
-		fromElementSpaces.add( space );
-		return space;
-	}
+	FromElementSpace makeFromElementSpace();
 }

--- a/src/main/java/org/hibernate/sqm/query/from/internal/DmlFromClause.java
+++ b/src/main/java/org/hibernate/sqm/query/from/internal/DmlFromClause.java
@@ -1,0 +1,54 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sqm.query.from.internal;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.sqm.parser.ParsingException;
+import org.hibernate.sqm.query.from.FromElementSpace;
+import org.hibernate.sqm.query.from.SqmFromClauseContainer;
+import org.hibernate.sqm.query.internal.AbstractSqmDmlStatement;
+
+/**
+ * Mimics a FromClause in relation to a DML statement, exporting the
+ * entity that is the target of the DML as the FromClause root FromElement
+ *
+ * @author Steve Ebersole
+ */
+public class DmlFromClause extends SqmFromClauseImpl {
+	private final DmlFromElementSpace fromElementSpace = new DmlFromElementSpace( this );
+	private final AbstractSqmDmlStatement dmlStatement;
+
+	public DmlFromClause(AbstractSqmDmlStatement dmlStatement, SqmFromClauseContainer fromClauseContainer) {
+		super( fromClauseContainer );
+		this.dmlStatement = dmlStatement;
+	}
+
+	public AbstractSqmDmlStatement getDmlStatement() {
+		return dmlStatement;
+	}
+
+	public DmlFromElementSpace getFromElementSpace() {
+		return fromElementSpace;
+	}
+
+	@Override
+	public List<FromElementSpace> getFromElementSpaces() {
+		return Collections.singletonList( fromElementSpace );
+	}
+
+	@Override
+	public void addFromElementSpace(FromElementSpace space) {
+		throw new ParsingException( "DML from-clause cannot have additional FromElementSpaces" );
+	}
+
+	@Override
+	public FromElementSpace makeFromElementSpace() {
+		throw new ParsingException( "DML from-clause cannot have additional FromElementSpaces" );
+	}
+}

--- a/src/main/java/org/hibernate/sqm/query/from/internal/DmlFromElementSpace.java
+++ b/src/main/java/org/hibernate/sqm/query/from/internal/DmlFromElementSpace.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sqm.query.from.internal;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.sqm.parser.ParsingException;
+import org.hibernate.sqm.query.from.FromElementSpace;
+import org.hibernate.sqm.query.from.SqmJoin;
+import org.hibernate.sqm.query.from.SqmRoot;
+
+/**
+ * Mimics a FromElementSpace in relation to a DML statement.  There will only be one
+ * FromElementSpace for the DML Statement
+ *
+ * @author Steve Ebersole
+ */
+public class DmlFromElementSpace extends FromElementSpace {
+	DmlFromElementSpace(DmlFromClause fromClause) {
+		super( fromClause );
+	}
+
+	@Override
+	public void setRoot(SqmRoot root) {
+		super.setRoot( root );
+		dmlFromClause().getDmlStatement().setEntityFromElement( root );
+	}
+
+	private DmlFromClause dmlFromClause() {
+		return (DmlFromClause) getFromClause();
+	}
+
+	@Override
+	public List<SqmJoin> getJoins() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public void addJoin(SqmJoin join) {
+		throw new ParsingException( "DML from-clause cannot define joins" );
+	}
+}

--- a/src/main/java/org/hibernate/sqm/query/from/internal/InFlightSqmFromClauseContainer.java
+++ b/src/main/java/org/hibernate/sqm/query/from/internal/InFlightSqmFromClauseContainer.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sqm.query.from.internal;
+
+import org.hibernate.sqm.query.from.SqmFromClauseContainer;
+import org.hibernate.sqm.query.internal.SqmQuerySpecImpl;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface InFlightSqmFromClauseContainer extends SqmFromClauseContainer {
+}

--- a/src/main/java/org/hibernate/sqm/query/from/internal/SqmFromClauseImpl.java
+++ b/src/main/java/org/hibernate/sqm/query/from/internal/SqmFromClauseImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sqm.query.from.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.sqm.query.from.FromElementSpace;
+import org.hibernate.sqm.query.from.SqmFromClause;
+import org.hibernate.sqm.query.from.SqmFromClauseContainer;
+
+/**
+ * @author Steve Ebersole
+ */
+public class SqmFromClauseImpl implements SqmFromClause {
+	private final SqmFromClauseContainer container;
+
+	private List<FromElementSpace> fromElementSpaces = new ArrayList<>();
+
+	public SqmFromClauseImpl(SqmFromClauseContainer container) {
+		this.container = container;
+	}
+
+	@Override
+	public SqmFromClauseContainer getContainer() {
+		return container;
+	}
+
+	public List<FromElementSpace> getFromElementSpaces() {
+		return fromElementSpaces;
+	}
+
+	public void addFromElementSpace(FromElementSpace space) {
+
+	}
+	public FromElementSpace makeFromElementSpace() {
+		final FromElementSpace space = new FromElementSpace( this );
+		fromElementSpaces.add( space );
+		return space;
+	}
+}

--- a/src/main/java/org/hibernate/sqm/query/internal/AbstractSqmDmlStatement.java
+++ b/src/main/java/org/hibernate/sqm/query/internal/AbstractSqmDmlStatement.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sqm.query.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hibernate.sqm.query.SqmQuerySpec;
+import org.hibernate.sqm.query.SqmStatementNonSelect;
+import org.hibernate.sqm.query.from.SqmRoot;
+
+/**
+ * @author Steve Ebersole
+ */
+public abstract class AbstractSqmDmlStatement
+		extends AbstractSqmStatement
+		implements SqmStatementNonSelect, InFlightSqmSubQueryContainer {
+	private SqmRoot entityFromElement;
+	private List<SqmQuerySpecImpl> subQuerySpecs;
+
+	@Override
+	public SqmRoot getEntityFromElement() {
+		return entityFromElement;
+	}
+
+	public void setEntityFromElement(SqmRoot entityFromElement) {
+		this.entityFromElement = entityFromElement;
+	}
+
+	@Override
+	public List<SqmQuerySpec> getSubQuerySpecs() {
+		return subQuerySpecs.stream().collect( Collectors.toList() );
+	}
+
+	@Override
+	public void addSubQuerySpec(SqmQuerySpecImpl subQuerySpec) {
+		if ( subQuerySpec.getSubQueryContainerContainer() != this ) {
+			throw new IllegalArgumentException(
+					"Can only add subquery query-specs whose containing FromClauseContainer is the same as this SQM statement"
+			);
+		}
+
+		if ( subQuerySpecs == null ) {
+			subQuerySpecs = new ArrayList<>();
+		}
+
+		subQuerySpecs.add( subQuerySpec );
+	}
+
+}

--- a/src/main/java/org/hibernate/sqm/query/internal/AbstractSqmInsertStatement.java
+++ b/src/main/java/org/hibernate/sqm/query/internal/AbstractSqmInsertStatement.java
@@ -10,26 +10,18 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.hibernate.sqm.query.expression.domain.SingularAttributeBinding;
 import org.hibernate.sqm.query.SqmInsertStatement;
-import org.hibernate.sqm.query.from.SqmRoot;
+import org.hibernate.sqm.query.expression.domain.SingularAttributeBinding;
 
 /**
  * Convenience base class for InsertSqmStatement implementations.
  *
  * @author Steve Ebersole
  */
-public abstract class AbstractSqmInsertStatement extends AbstractSqmStatement implements SqmInsertStatement {
-	private final SqmRoot insertTarget;
+public abstract class AbstractSqmInsertStatement extends AbstractSqmDmlStatement implements SqmInsertStatement {
 	private List<SingularAttributeBinding> stateFields;
 
-	public AbstractSqmInsertStatement(SqmRoot insertTarget) {
-		this.insertTarget = insertTarget;
-	}
-
-	@Override
-	public SqmRoot getInsertTarget() {
-		return insertTarget;
+	public AbstractSqmInsertStatement() {
 	}
 
 	@Override

--- a/src/main/java/org/hibernate/sqm/query/internal/InFlightSqmSubQueryContainer.java
+++ b/src/main/java/org/hibernate/sqm/query/internal/InFlightSqmSubQueryContainer.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sqm.query.internal;
+
+import org.hibernate.sqm.query.SqmSubQueryContainer;
+
+/**
+ * @author Steve Ebersole
+ */
+public interface InFlightSqmSubQueryContainer extends SqmSubQueryContainer {
+	void addSubQuerySpec(SqmQuerySpecImpl subQuerySpec);
+}

--- a/src/main/java/org/hibernate/sqm/query/internal/SqmDeleteStatementImpl.java
+++ b/src/main/java/org/hibernate/sqm/query/internal/SqmDeleteStatementImpl.java
@@ -16,17 +16,14 @@ import org.hibernate.sqm.query.predicate.SqmWhereClause;
 /**
  * @author Steve Ebersole
  */
-public class SqmDeleteStatementImpl extends AbstractSqmStatement implements SqmDeleteStatement {
-	private final SqmRoot entityFromElement;
-	private final SqmWhereClause whereClause = new SqmWhereClause();
+public class SqmDeleteStatementImpl extends AbstractSqmDmlStatement implements SqmDeleteStatement {
+	private SqmWhereClause whereClause;
 
-	public SqmDeleteStatementImpl(SqmRoot entityFromElement) {
-		this.entityFromElement = entityFromElement;
+	public SqmDeleteStatementImpl() {
 	}
 
-	@Override
-	public SqmRoot getEntityFromElement() {
-		return entityFromElement;
+	public void setWhereClause(SqmWhereClause whereClause) {
+		this.whereClause = whereClause;
 	}
 
 	@Override
@@ -39,7 +36,7 @@ public class SqmDeleteStatementImpl extends AbstractSqmStatement implements SqmD
 		return String.format(
 				Locale.ROOT,
 				"delete %s %s",
-				entityFromElement,
+				getEntityFromElement(),
 				whereClause
 		);
 	}

--- a/src/main/java/org/hibernate/sqm/query/internal/SqmInsertSelectStatementImpl.java
+++ b/src/main/java/org/hibernate/sqm/query/internal/SqmInsertSelectStatementImpl.java
@@ -9,7 +9,6 @@ package org.hibernate.sqm.query.internal;
 import org.hibernate.sqm.SemanticQueryWalker;
 import org.hibernate.sqm.query.SqmInsertSelectStatement;
 import org.hibernate.sqm.query.SqmQuerySpec;
-import org.hibernate.sqm.query.from.SqmRoot;
 
 /**
  * @author Steve Ebersole
@@ -17,8 +16,7 @@ import org.hibernate.sqm.query.from.SqmRoot;
 public class SqmInsertSelectStatementImpl extends AbstractSqmInsertStatement implements SqmInsertSelectStatement {
 	private SqmQuerySpec selectQuery;
 
-	public SqmInsertSelectStatementImpl(SqmRoot insertTarget) {
-		super( insertTarget );
+	public SqmInsertSelectStatementImpl() {
 	}
 
 	@Override

--- a/src/main/java/org/hibernate/sqm/query/internal/SqmQuerySpecImpl.java
+++ b/src/main/java/org/hibernate/sqm/query/internal/SqmQuerySpecImpl.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or http://www.gnu.org/licenses/lgpl-2.1.html
+ */
+package org.hibernate.sqm.query.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.sqm.query.SqmQuerySpec;
+import org.hibernate.sqm.query.from.SqmFromClause;
+import org.hibernate.sqm.query.from.internal.InFlightSqmFromClauseContainer;
+import org.hibernate.sqm.query.from.internal.SqmFromClauseImpl;
+import org.hibernate.sqm.query.predicate.SqmWhereClause;
+import org.hibernate.sqm.query.select.SqmSelectClause;
+
+/**
+ * @author Steve Ebersole
+ */
+public class SqmQuerySpecImpl implements SqmQuerySpec, InFlightSqmFromClauseContainer, InFlightSqmSubQueryContainer {
+	private final InFlightSqmSubQueryContainer subQueryContainerContainer;
+	private List<SqmQuerySpec> subQueries;
+
+	private final SqmFromClauseImpl fromClause = new SqmFromClauseImpl( this );
+	private SqmSelectClause selectClause;
+	private SqmWhereClause whereClause;
+
+	// todo : group-by + having
+
+	public SqmQuerySpecImpl(InFlightSqmSubQueryContainer subQueryContainerContainer) {
+		this.subQueryContainerContainer = subQueryContainerContainer;
+		if ( this.subQueryContainerContainer != null ) {
+			this.subQueryContainerContainer.addSubQuerySpec( this );
+		}
+	}
+
+	public InFlightSqmSubQueryContainer getSubQueryContainerContainer() {
+		return subQueryContainerContainer;
+	}
+
+	@Override
+	public void addSubQuerySpec(SqmQuerySpecImpl subQuerySpec) {
+		if ( subQuerySpec.getSubQueryContainerContainer() != this ) {
+			throw new IllegalArgumentException(
+					"Can only add subquery query-specs whose containing FromClauseContainer is the same as this SQM statement"
+			);
+		}
+
+		if ( subQueries == null ) {
+			subQueries = new ArrayList<>();
+		}
+		subQueries.add( subQuerySpec );
+	}
+
+	public void setSelectClause(SqmSelectClause selectClause) {
+		this.selectClause = selectClause;
+	}
+
+	public void setWhereClause(SqmWhereClause whereClause) {
+		this.whereClause = whereClause;
+	}
+
+	@Override
+	public SqmFromClause getFromClause() {
+		return fromClause;
+	}
+
+	@Override
+	public SqmSelectClause getSelectClause() {
+		return selectClause;
+	}
+
+	@Override
+	public SqmWhereClause getWhereClause() {
+		return whereClause;
+	}
+
+	@Override
+	public List<SqmQuerySpec> getSubQuerySpecs() {
+		if ( subQueries == null ) {
+			return Collections.emptyList();
+		}
+		else {
+			return Collections.unmodifiableList( subQueries );
+		}
+	}
+}

--- a/src/main/java/org/hibernate/sqm/query/internal/SqmUpdateStatementImpl.java
+++ b/src/main/java/org/hibernate/sqm/query/internal/SqmUpdateStatementImpl.java
@@ -17,18 +17,19 @@ import org.hibernate.sqm.query.set.SqmSetClause;
 /**
  * @author Steve Ebersole
  */
-public class SqmUpdateStatementImpl extends AbstractSqmStatement implements SqmUpdateStatement {
-	private final SqmRoot entityFromElement;
-	private final SqmSetClause setClause = new SqmSetClause();
-	private final SqmWhereClause whereClause = new SqmWhereClause();
+public class SqmUpdateStatementImpl extends AbstractSqmDmlStatement implements SqmUpdateStatement {
+	private SqmSetClause setClause;
+	private SqmWhereClause whereClause;
 
-	public SqmUpdateStatementImpl(SqmRoot entityFromElement) {
-		this.entityFromElement = entityFromElement;
+	public SqmUpdateStatementImpl() {
 	}
 
-	@Override
-	public SqmRoot getEntityFromElement() {
-		return entityFromElement;
+	public void setSetClause(SqmSetClause setClause) {
+		this.setClause = setClause;
+	}
+
+	public void setWhereClause(SqmWhereClause whereClause) {
+		this.whereClause = whereClause;
 	}
 
 	@Override
@@ -46,7 +47,7 @@ public class SqmUpdateStatementImpl extends AbstractSqmStatement implements SqmU
 		return String.format(
 				Locale.ROOT,
 				"update %s %s %s",
-				entityFromElement,
+				getEntityFromElement(),
 				"[no set clause]",
 				whereClause
 		);

--- a/src/test/java/org/hibernate/test/sqm/parser/hql/dml/BasicInsertTests.java
+++ b/src/test/java/org/hibernate/test/sqm/parser/hql/dml/BasicInsertTests.java
@@ -41,10 +41,10 @@ public class BasicInsertTests {
 		assertThat( statement, instanceOf( SqmInsertSelectStatement.class ) );
 		SqmInsertSelectStatement insertStatement = (SqmInsertSelectStatement) statement;
 
-		assertThat( insertStatement.getInsertTarget().getEntityName(), equalTo( "com.acme.Entity1" ) );
+		assertThat( insertStatement.getEntityFromElement().getEntityName(), equalTo( "com.acme.Entity1" ) );
 
 		for ( SingularAttributeBinding stateField : insertStatement.getStateFields() ) {
-			assertSame( insertStatement.getInsertTarget(), stateField.getLhs().getFromElement() );
+			assertSame( insertStatement.getEntityFromElement(), stateField.getLhs().getFromElement() );
 		}
 	}
 


### PR DESCRIPTION
@dreab8 @Naros What do y'all think of these changes to track subqueries to later allow join promotion/hoisting?  The idea of promoting or hoisting a join is cases where we initially render a join as part of a subquery, but later find the "same join" defined in an outer query - in such cases we can move the join (promote it or hoist it) into the outer query which will be more efficient SQL in the vast majority of cases.